### PR TITLE
Text Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ venv
 .tox
 
 # Test artifacts
-tests/functional/output/*
+tests/output/*
 
 # PyCharm
 .idea

--- a/pangocairohelpers/__init__.py
+++ b/pangocairohelpers/__init__.py
@@ -1,3 +1,4 @@
+from .glyph_extents import GlyphExtents  # noqa
 from . import point_helper  # noqa
 from . import line_helper  # noqa
 from . import line_string_helper  # noqa

--- a/pangocairohelpers/glyph_extents.py
+++ b/pangocairohelpers/glyph_extents.py
@@ -1,0 +1,15 @@
+class GlyphExtents:
+
+    def __init__(
+            self,
+            x: float = 0,
+            y: float = 0,
+            width: float = 0,
+            height: float = 0,
+            baseline: float = 0
+    ):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+        self.baseline = baseline

--- a/pangocairohelpers/layout_clusters.py
+++ b/pangocairohelpers/layout_clusters.py
@@ -1,8 +1,6 @@
 from pangocffi import Layout, GlyphItem, units_to_double
 from typing import List, Optional
 
-from shapely.geometry import Point
-
 from pangocairohelpers import GlyphExtents
 
 

--- a/pangocairohelpers/layout_clusters.py
+++ b/pangocairohelpers/layout_clusters.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 
 from shapely.geometry import Point
 
+from pangocairohelpers import GlyphExtents
+
 
 class LayoutClusters:
     """
@@ -24,7 +26,7 @@ class LayoutClusters:
         self.layout = layout
         self.text = self.layout.get_text()
         self.clusters = []
-        self.logical_positions = []
+        self.logical_extents = []
         self._extract_properties_from_layout()
 
     def _extract_properties_from_layout(self):
@@ -52,8 +54,11 @@ class LayoutClusters:
                 cluster_extents = layout_cluster_iter.get_cluster_extents()[1]
                 layout_cluster_iter.next_cluster()
                 self.clusters.append(cluster)
-                self.logical_positions.append(Point(
+                self.logical_extents.append(GlyphExtents(
                     units_to_double(cluster_extents.x),
+                    units_to_double(cluster_extents.y),
+                    units_to_double(cluster_extents.width),
+                    units_to_double(cluster_extents.height),
                     units_to_double(layout_line_baseline)
                 ))
 
@@ -122,10 +127,9 @@ class LayoutClusters:
         """
         return self.clusters
 
-    def get_logical_positions(self) -> List[Point]:
+    def get_logical_extents(self) -> List[GlyphExtents]:
         """
         :return:
-            a list of ``Point`` representing the top left position of the
-            logical extent of each cluster in the layout
+            a list of ``GlyphExtents`` for each cluster in the layout
         """
-        return self.logical_positions
+        return self.logical_extents

--- a/pangocairohelpers/text_path/__init__.py
+++ b/pangocairohelpers/text_path/__init__.py
@@ -1,0 +1,2 @@
+from .text_path_glyph_item import TextPathGlyphItem
+from .text_path import TextPath

--- a/pangocairohelpers/text_path/__init__.py
+++ b/pangocairohelpers/text_path/__init__.py
@@ -1,3 +1,4 @@
 from .text_path_glyph_item import TextPathGlyphItem
+from .standard_layout_engine import StandardLayoutEngine
 from .text_path import TextPath
 from .upright_text_path import UprightTextPath

--- a/pangocairohelpers/text_path/__init__.py
+++ b/pangocairohelpers/text_path/__init__.py
@@ -1,4 +1,3 @@
 from .text_path_glyph_item import TextPathGlyphItem
-from .standard_layout_engine import StandardLayoutEngine
 from .text_path import TextPath
 from .upright_text_path import UprightTextPath

--- a/pangocairohelpers/text_path/__init__.py
+++ b/pangocairohelpers/text_path/__init__.py
@@ -1,2 +1,3 @@
 from .text_path_glyph_item import TextPathGlyphItem
 from .text_path import TextPath
+from .upright_text_path import UprightTextPath

--- a/pangocairohelpers/text_path/__init__.py
+++ b/pangocairohelpers/text_path/__init__.py
@@ -1,3 +1,3 @@
-from .text_path_glyph_item import TextPathGlyphItem
-from .text_path import TextPath
-from .upright_text_path import UprightTextPath
+from .text_path_glyph_item import TextPathGlyphItem  # noqa
+from .text_path import TextPath  # noqa
+from .upright_text_path import UprightTextPath  # noqa

--- a/pangocairohelpers/text_path/layout_engines/__init__.py
+++ b/pangocairohelpers/text_path/layout_engines/__init__.py
@@ -1,1 +1,1 @@
-from .svg import Svg
+from .svg import Svg  # noqa

--- a/pangocairohelpers/text_path/layout_engines/__init__.py
+++ b/pangocairohelpers/text_path/layout_engines/__init__.py
@@ -1,0 +1,1 @@
+from .svg import Svg

--- a/pangocairohelpers/text_path/layout_engines/svg.py
+++ b/pangocairohelpers/text_path/layout_engines/svg.py
@@ -1,14 +1,15 @@
-from typing import List, Tuple
+import math
+from typing import List
 
 from pangocffi import Alignment
 from shapely.geometry import LineString
 
-from pangocairohelpers import LayoutClusters
+from pangocairohelpers import LayoutClusters, point_helper
 from pangocairohelpers import line_string_helper
 from pangocairohelpers.text_path import TextPathGlyphItem
 
 
-class StandardLayoutEngine:
+class Svg:
 
     def __init__(
             self,
@@ -37,21 +38,26 @@ class StandardLayoutEngine:
         glyph_items_and_extents = zip(glyph_items, extents)
         for glyph_item, extent in glyph_items_and_extents:
 
-            offset = self.start_offset + extent.x
+            glyph_width = extent.width
+            offset = self.start_offset + extent.x + glyph_width / 2
 
             # Cut off rendering the rest of the text if there no more space
             # to layout the text
             if line_string_length < offset:
                 break
 
-            position = self.line_string.interpolate(offset)
+            center_position = self.line_string.interpolate(offset)
             rotation = line_string_helper.angle_at_offset(
                 angles_at_offsets, offset
             )
 
+            left_position = point_helper.add_polar_vector(
+                center_position, rotation + math.pi, glyph_width / 2
+            )
+
             text_path_glyph_item = TextPathGlyphItem(
                 glyph_item,
-                position,
+                left_position,
                 rotation
             )
             text_path_glyph_items.append(text_path_glyph_item)

--- a/pangocairohelpers/text_path/standard_layout_engine.py
+++ b/pangocairohelpers/text_path/standard_layout_engine.py
@@ -4,6 +4,8 @@ from pangocffi import Alignment
 from shapely.geometry import LineString
 
 from pangocairohelpers import LayoutClusters
+from pangocairohelpers import line_string_helper
+from pangocairohelpers.text_path import TextPathGlyphItem
 
 
 class StandardLayoutEngine:
@@ -19,14 +21,39 @@ class StandardLayoutEngine:
         self.alignment = alignment
         self.start_offset = 0
 
-    def generate_positions_and_rotations(self) -> List[Tuple[float, float]]:
-        positions = []
-        rotations = []
+    # def _find_
 
+    def generate_text_path_glyph_items(self) -> List[TextPathGlyphItem]:
+        text_path_glyph_items = []
+
+        angles_at_offsets = line_string_helper.angles_at_offsets(
+            self.line_string
+        )
+
+        line_string_length = self.line_string.length
+
+        glyph_items = self.layout_clusters.get_clusters()
         extents = self.layout_clusters.get_logical_extents()
-        for extent in extents:
-            position = self.line_string.interpolate(
-                self.start_offset + extent.x
-            )
-            rotation =
+        glyph_items_and_extents = zip(glyph_items, extents)
+        for glyph_item, extent in glyph_items_and_extents:
 
+            offset = self.start_offset + extent.x
+
+            # Cut off rendering the rest of the text if there no more space
+            # to layout the text
+            if line_string_length < offset:
+                break
+
+            position = self.line_string.interpolate(offset)
+            rotation = line_string_helper.angle_at_offset(
+                angles_at_offsets, offset
+            )
+
+            text_path_glyph_item = TextPathGlyphItem(
+                glyph_item,
+                position,
+                rotation
+            )
+            text_path_glyph_items.append(text_path_glyph_item)
+
+        return text_path_glyph_items

--- a/pangocairohelpers/text_path/standard_layout_engine.py
+++ b/pangocairohelpers/text_path/standard_layout_engine.py
@@ -1,0 +1,32 @@
+from typing import List, Tuple
+
+from pangocffi import Alignment
+from shapely.geometry import LineString
+
+from pangocairohelpers import LayoutClusters
+
+
+class StandardLayoutEngine:
+
+    def __init__(
+            self,
+            line_string: LineString,
+            layout_clusters: LayoutClusters,
+            alignment: Alignment = Alignment.LEFT
+    ):
+        self.line_string = line_string
+        self.layout_clusters = layout_clusters
+        self.alignment = alignment
+        self.start_offset = 0
+
+    def generate_positions_and_rotations(self) -> List[Tuple[float, float]]:
+        positions = []
+        rotations = []
+
+        extents = self.layout_clusters.get_logical_extents()
+        for extent in extents:
+            position = self.line_string.interpolate(
+                self.start_offset + extent.x
+            )
+            rotation =
+

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -46,9 +46,12 @@ class TextPath:
         logical_positions = self.layout_clusters.get_logical_positions()
         text_path_glyph_items = []
         for glyph_item, logical_position in zip(glyph_items, logical_positions):
+            glyph_start_position = self.line_string.interpolate(
+                logical_position.x
+            )
             text_path_glyph_item = TextPathGlyphItem(
                 glyph_item,
-                logical_position,
+                glyph_start_position,
                 0
             )
             text_path_glyph_items.append(text_path_glyph_item)
@@ -61,13 +64,12 @@ class TextPath:
     def draw(self, context: Context):
         text_path_glyph_items = self.get_text_path_glyph_items()
         for text_path_glyph_item in text_path_glyph_items:
+            glyph_position = text_path_glyph_item.position
+            glyph_rotation = text_path_glyph_item.rotation
+
             context.save()
-            # Todo: Get correct translation
-            # context.translate(
-            #     pangocffi.units_to_double(layout_run_extents.x),
-            #     pangocffi.units_to_double(layout_line_baseline)
-            # )
-            context.rotate(text_path_glyph_item.rotation)
+            context.translate(glyph_position.x, glyph_position.y)
+            context.rotate(glyph_rotation)
             show_glyph_item(
                 context,
                 self.layout_text,

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 from cairocffi import Context
 from pangocffi import Layout, Alignment
@@ -7,7 +7,7 @@ from shapely.geometry import LineString, MultiPolygon
 from pangocairocffi.render_functions import show_glyph_item
 
 from pangocairohelpers import LayoutClusters
-from pangocairohelpers.text_path import TextPathGlyphItem, StandardLayoutEngine
+from pangocairohelpers.text_path.layout_engines import Svg as SvgLayoutEngine
 from pangocairohelpers import line_string_helper
 
 
@@ -36,7 +36,7 @@ class TextPath:
         self.line_string = line_string
         self.layout_clusters = LayoutClusters(self.layout)
         self.alignment = alignment
-        self.layout_engine = StandardLayoutEngine(
+        self.layout_engine = SvgLayoutEngine(
             self.line_string,
             self.layout_clusters,
             self.alignment
@@ -147,4 +147,3 @@ class TextPath:
                 text_path_glyph_item.glyph_item
             )
             context.restore()
-

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -35,10 +35,12 @@ class TextPath:
         # Todo: throw an error if the layout is multi-lined
 
     def text_fits(self) -> bool:
+        # Todo: is this algorithm realistic?
         last_position = self.layout_clusters.get_logical_positions()[-1]
         return last_position.x < self.line_string.length
 
     def get_text_path_glyph_items(self) -> List[TextPathGlyphItem]:
+        # Todo: Make this function correct
         glyph_items = self.layout_clusters.get_clusters()
         logical_positions = self.layout_clusters.get_logical_positions()
         text_path_glyph_items = []
@@ -52,14 +54,23 @@ class TextPath:
         return text_path_glyph_items
 
     def compute_boundaries(self) -> MultiPolygon:
+        # Todo:
         pass
 
     def draw(self, context: Context):
         text_path_glyph_items = self.get_text_path_glyph_items()
         for text_path_glyph_item in text_path_glyph_items:
+            context.save()
+            # Todo: Get correct translation
+            # context.translate(
+            #     pangocffi.units_to_double(layout_run_extents.x),
+            #     pangocffi.units_to_double(layout_line_baseline)
+            # )
+            context.rotate(text_path_glyph_item.rotation)
             show_glyph_item(
                 context,
                 self.layout_text,
                 text_path_glyph_item.glyph_item
             )
+            context.restore()
 

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -26,13 +26,14 @@ class TextPath:
             layout: Layout,
             alignment: Alignment = Alignment.LEFT
     ):
+        if layout.get_line_count() > 1:
+            raise ValueError('layout cannot be more than one line.')
+
         self.layout = layout
         self.layout_text = layout.get_text()
         self.line_string = line_string
         self.layout_clusters = LayoutClusters(self.layout)
         self.alignment = alignment
-
-        # Todo: throw an error if the layout is multi-lined
 
     def text_fits(self) -> bool:
         # Todo: is this algorithm realistic?

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from cairocffi import Context
-from pangocffi import Layout
+from pangocffi import Layout, Alignment
 from shapely.geometry import LineString, MultiPolygon
 from pangocairocffi.render_functions import show_glyph_item
 
@@ -20,11 +20,17 @@ class TextPath:
     Left-to-right text is assumed.
     """
 
-    def __init__(self, line_string: LineString, layout: Layout):
+    def __init__(
+            self,
+            line_string: LineString,
+            layout: Layout,
+            alignment: Alignment = Alignment.LEFT
+    ):
         self.layout = layout
         self.layout_text = layout.get_text()
         self.line_string = line_string
         self.layout_clusters = LayoutClusters(self.layout)
+        self.alignment = alignment
 
         # Todo: throw an error if the layout is multi-lined
 

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -39,7 +39,7 @@ class TextPath:
 
     def text_fits(self) -> bool:
         # Todo: is this algorithm realistic?
-        last_position = self.layout_clusters.get_logical_positions()[-1]
+        last_position = self.layout_clusters.get_logical_extents()[-1]
         return last_position.x < self.line_string.length
 
     def _calculate_rotation_between_two_offsets(
@@ -119,7 +119,7 @@ class TextPath:
     def get_text_path_glyph_items(self) -> List[TextPathGlyphItem]:
         # Todo: Make this function correct
         glyph_items = self.layout_clusters.get_clusters()
-        logical_positions = self.layout_clusters.get_logical_positions()
+        logical_positions = self.layout_clusters.get_logical_extents()
         text_path_glyph_items = []
 
         line_string_offset = 0

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -1,6 +1,3 @@
-import math
-from typing import Optional, Tuple
-
 from cairocffi import Context
 from pangocffi import Layout, Alignment
 from shapely.geometry import LineString, MultiPolygon
@@ -8,7 +5,6 @@ from pangocairocffi.render_functions import show_glyph_item
 
 from pangocairohelpers import LayoutClusters
 from pangocairohelpers.text_path.layout_engines import Svg as SvgLayoutEngine
-from pangocairohelpers import line_string_helper
 
 
 class TextPath:
@@ -26,7 +22,8 @@ class TextPath:
             self,
             line_string: LineString,
             layout: Layout,
-            alignment: Alignment = Alignment.LEFT
+            alignment: Alignment = Alignment.LEFT,
+            layout_engine=SvgLayoutEngine
     ):
         if layout.get_line_count() > 1:
             raise ValueError('layout cannot be more than one line.')
@@ -36,7 +33,7 @@ class TextPath:
         self.line_string = line_string
         self.layout_clusters = LayoutClusters(self.layout)
         self.alignment = alignment
-        self.layout_engine = SvgLayoutEngine(
+        self.layout_engine = layout_engine(
             self.line_string,
             self.layout_clusters,
             self.alignment
@@ -44,83 +41,14 @@ class TextPath:
         self.text_path_glyph_items = None
 
     def text_fits(self) -> bool:
-        # Todo: is this algorithm realistic?
-        last_position = self.layout_clusters.get_logical_extents()[-1]
-        return last_position.x < self.line_string.length
-
-    def _calculate_rotation_between_two_offsets(
-            self,
-            offset_a: float,
-            offset_b: float
-    ):
         """
-        :param offset_a:
-            the starting offset
-        :param offset_b: 
-            the ending offset
         :return:
-            the rotation in radians relative to the positive x axis 
+            true if all the glyphs can be rendered on the line
         """
-        offset_a_point = self.line_string.interpolate(offset_a)
-        offset_b_point = self.line_string.interpolate(offset_b)
-        return math.atan2(
-            offset_b_point.y - offset_a_point.y,
-            offset_b_point.x - offset_a_point.x
-        )
-
-    def _calculate_rotation_for_glyph_item_at_offset(
-            self,
-            offset: float,
-            distance: float
-    ) -> Optional[float]:
-        """
-        :param offset:
-        :param distance:
-
-        :return:
-            the angle that this glyph must use when following the path.
-        """
-        new_offset = line_string_helper.next_offset_from_offset_in_line_string(
-            self.line_string,
-            offset,
-            distance
-        )
-        if new_offset is None:
-            return None
-        offset_point = self.line_string.interpolate(offset)
-        new_offset_point = self.line_string.interpolate(new_offset)
-        return math.atan2(
-            new_offset_point.y - offset_point.y,
-            new_offset_point.x - offset_point.x
-        )
-    
-    def get_rotation_and_next_offset_for_glyph_item(
-            self,
-            logical_width: float,
-            offset: float
-    ) -> Optional[Tuple[float, float]]:
-        """
-        :param logical_width:
-            the logical width of the glyph item
-        :param offset: 
-            the offset to start from
-        :return:
-            a tuple of rotation and the next offset to start the next
-            glyph item. ``None`` if there are no more offsets to reach
-        """
-        new_offset = line_string_helper.next_offset_from_offset_in_line_string(
-            self.line_string,
-            offset,
-            logical_width
-        )
-        if new_offset is None:
-            return None
-        
-        rotation = self._calculate_rotation_for_glyph_item_at_offset(
-            offset,
-            new_offset
-        )
-        return rotation, new_offset
+        text_path_glyph_items = self._compute_text_path_glyph_items()
+        number_of_layed_out_glyphs = len(text_path_glyph_items)
+        number_of_total_glyphs = len(self.layout_clusters.get_clusters())
+        return number_of_layed_out_glyphs == number_of_total_glyphs
 
     def _compute_text_path_glyph_items(self):
         if self.text_path_glyph_items is None:
@@ -133,6 +61,12 @@ class TextPath:
         pass
 
     def draw(self, context: Context):
+        """
+        Draws the text path on the context
+
+        :param context:
+            a cairo context
+        """
         text_path_glyph_items = self._compute_text_path_glyph_items()
         for text_path_glyph_item in text_path_glyph_items:
             glyph_position = text_path_glyph_item.position

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -1,0 +1,59 @@
+from typing import List
+
+from cairocffi import Context
+from pangocffi import Layout
+from shapely.geometry import LineString, MultiPolygon
+from pangocairocffi.render_functions import show_glyph_item
+
+from pangocairohelpers import LayoutClusters
+from pangocairohelpers.text_path import TextPathGlyphItem
+
+
+class TextPath:
+    """
+    Renders text similar to the behaviour found in SVG's ``<textPath>``.
+
+    ``line_string`` behaves as the baseline for the text in the layout.
+
+    Multi-line layouts are not supported and will throw an error.
+
+    Left-to-right text is assumed.
+    """
+
+    def __init__(self, line_string: LineString, layout: Layout):
+        self.layout = layout
+        self.layout_text = layout.get_text()
+        self.line_string = line_string
+        self.layout_clusters = LayoutClusters(self.layout)
+
+        # Todo: throw an error if the layout is multi-lined
+
+    def text_fits(self) -> bool:
+        last_position = self.layout_clusters.get_logical_positions()[-1]
+        return last_position.x < self.line_string.length
+
+    def get_text_path_glyph_items(self) -> List[TextPathGlyphItem]:
+        glyph_items = self.layout_clusters.get_clusters()
+        logical_positions = self.layout_clusters.get_logical_positions()
+        text_path_glyph_items = []
+        for glyph_item, logical_position in zip(glyph_items, logical_positions):
+            text_path_glyph_item = TextPathGlyphItem(
+                glyph_item,
+                logical_position,
+                0
+            )
+            text_path_glyph_items.append(text_path_glyph_item)
+        return text_path_glyph_items
+
+    def compute_boundaries(self) -> MultiPolygon:
+        pass
+
+    def draw(self, context: Context):
+        text_path_glyph_items = self.get_text_path_glyph_items()
+        for text_path_glyph_item in text_path_glyph_items:
+            show_glyph_item(
+                context,
+                self.layout_text,
+                text_path_glyph_item.glyph_item
+            )
+

--- a/pangocairohelpers/text_path/text_path_glyph_item.py
+++ b/pangocairohelpers/text_path/text_path_glyph_item.py
@@ -1,0 +1,18 @@
+from pangocffi import GlyphItem
+from shapely.geometry import Point
+
+
+class TextPathGlyphItem:
+    """
+    An individual glyphItem component that is part of the TextPath
+    """
+
+    def __init__(
+            self,
+            glyph_item: GlyphItem,
+            position: Point,
+            rotation: float
+    ):
+        self.glyph_item = glyph_item
+        self.position = position
+        self.rotation = rotation

--- a/pangocairohelpers/text_path/upright_text_path.py
+++ b/pangocairohelpers/text_path/upright_text_path.py
@@ -1,0 +1,5 @@
+class UprightTextPath:
+    """
+    A TextPath that when drawn, will always try to make sure the glyphs are
+    never rendered upside down for poor readability.
+    """

--- a/tests/functional/debug.py
+++ b/tests/functional/debug.py
@@ -1,0 +1,13 @@
+from cairocffi import Context
+from shapely.geometry import LineString
+
+
+def draw_line_string(cairo_context: Context, line_string: LineString):
+    start = True
+    for x, y in line_string.coords:
+        if start:
+            cairo_context.move_to(x, y)
+        else:
+            cairo_context.line_to(x, y)
+
+        start = False

--- a/tests/functional/test_layout_clusters.py
+++ b/tests/functional/test_layout_clusters.py
@@ -14,6 +14,6 @@ def test_layout_clusters_properties_have_same_length():
 
     assert layout_clusters.get_layout() is layout
     assert len(layout_clusters.get_clusters()) == expected_length
-    assert len(layout_clusters.get_logical_positions()) == expected_length
+    assert len(layout_clusters.get_logical_extents()) == expected_length
 
     surface.finish()

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -43,7 +43,7 @@ class TestTextPath(unittest.TestCase):
         debug.draw_line_string(cairo_context, line_string)
         cairo_context.stroke()
 
-        line_string = LineString([[10, 50], [20, 50], [23, 60], [25, 50], [50, 50], [90, 90]])
+        line_string = LineString([[10, 50], [50, 50], [90, 90]])
         text_path = TextPath(line_string, layout)
         text_path.draw(cairo_context)
 

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -1,0 +1,32 @@
+from cairocffi import Context, SVGSurface
+import pangocairocffi
+from shapely.geometry import LineString
+import unittest
+
+from pangocairohelpers.text_path import TextPath
+
+
+class TestTextPath(unittest.TestCase):
+
+    def test_error_is_raised_for_multi_line(self):
+        surface = SVGSurface(None, 100, 100)
+        cairo_context = Context(surface)
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語\nThis is a text')
+
+        line_string = LineString([[0, 0], [100, 0]])
+
+        with self.assertRaises(ValueError):
+            TextPath(line_string, layout)
+
+    def test_glyph(self):
+        surface = SVGSurface(None, 100, 100)
+        cairo_context = Context(surface)
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語')
+
+        line_string = LineString([[0, 0], [100, 0]])
+
+        text_path = TextPath(line_string, layout)
+
+        surface.finish()

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -31,6 +31,28 @@ class TestTextPath(unittest.TestCase):
         with self.assertRaises(ValueError):
             TextPath(line_string, layout)
 
+    def test_text_fits(self):
+        surface, cairo_context = self._create_real_surface()
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語')
+
+        line_string = LineString([[0, 0], [100, 0]])
+        text_path = TextPath(line_string, layout)
+        assert text_path.text_fits()
+
+        line_string = LineString([[0, 0], [50, 0]])
+        text_path = TextPath(line_string, layout)
+        assert not text_path.text_fits()
+
+    def test_compute_boundaries(self):
+        surface, cairo_context = self._create_real_surface()
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語')
+
+        line_string = LineString([[0, 0], [100, 0]])
+        text_path = TextPath(line_string, layout)
+        assert text_path.compute_boundaries() is None
+
     def test_glyph(self):
         surface, cairo_context = self._create_real_surface()
         layout = pangocairocffi.create_layout(cairo_context)

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -36,7 +36,7 @@ class TestTextPath(unittest.TestCase):
         layout = pangocairocffi.create_layout(cairo_context)
         layout.set_markup('Hi from Παν語')
 
-        line_string = LineString([[0, 0], [100, 0]])
+        line_string = LineString([[0, 0], [600, 0]])
         text_path = TextPath(line_string, layout)
         assert text_path.text_fits()
 

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -6,6 +6,7 @@ from shapely.geometry import LineString
 import unittest
 
 from pangocairohelpers.text_path import TextPath
+from . import debug
 
 
 class TestTextPath(unittest.TestCase):
@@ -36,9 +37,17 @@ class TestTextPath(unittest.TestCase):
         layout.set_markup('Hi from Παν語')
 
         line_string = LineString([[10, 30], [90, 30]])
-
         text_path = TextPath(line_string, layout)
-
         text_path.draw(cairo_context)
+
+        debug.draw_line_string(cairo_context, line_string)
+        cairo_context.stroke()
+
+        line_string = LineString([[10, 50], [20, 50], [23, 60], [25, 50], [50, 50], [90, 90]])
+        text_path = TextPath(line_string, layout)
+        text_path.draw(cairo_context)
+
+        debug.draw_line_string(cairo_context, line_string)
+        cairo_context.stroke()
 
         surface.finish()

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -1,4 +1,6 @@
-from cairocffi import Context, SVGSurface
+from typing import Tuple
+
+from cairocffi import Context, SVGSurface, Surface
 import pangocairocffi
 from shapely.geometry import LineString
 import unittest
@@ -8,9 +10,18 @@ from pangocairohelpers.text_path import TextPath
 
 class TestTextPath(unittest.TestCase):
 
-    def test_error_is_raised_for_multi_line(self):
+    def _create_void_surface(self) -> Tuple[Surface, Context]:
         surface = SVGSurface(None, 100, 100)
         cairo_context = Context(surface)
+        return surface, cairo_context
+
+    def _create_real_surface(self) -> Tuple[Surface, Context]:
+        surface = SVGSurface('tests/output/test.svg', 100, 100)
+        cairo_context = Context(surface)
+        return surface, cairo_context
+
+    def test_error_is_raised_for_multi_line(self):
+        surface, cairo_context = self._create_void_surface()
         layout = pangocairocffi.create_layout(cairo_context)
         layout.set_markup('Hi from Παν語\nThis is a text')
 
@@ -20,13 +31,14 @@ class TestTextPath(unittest.TestCase):
             TextPath(line_string, layout)
 
     def test_glyph(self):
-        surface = SVGSurface(None, 100, 100)
-        cairo_context = Context(surface)
+        surface, cairo_context = self._create_real_surface()
         layout = pangocairocffi.create_layout(cairo_context)
         layout.set_markup('Hi from Παν語')
 
-        line_string = LineString([[0, 0], [100, 0]])
+        line_string = LineString([[10, 30], [90, 30]])
 
         text_path = TextPath(line_string, layout)
+
+        text_path.draw(cairo_context)
 
         surface.finish()


### PR DESCRIPTION
This PR adds a class that allows rendering of text along a path. It can be used like this.

```python
text_path = TextPath(line_string, layout)
text_path.draw(context)
```

The standard layout engine will mimic the behaviour available in SVG: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/textPath

This uses the idea that the centre position of the glyph will determine the orientation and position along the line string.

![explantion](https://user-images.githubusercontent.com/3501061/57195151-2f64b100-6f47-11e9-8c66-1e4e0794b84d.png)

Additional features of SVG have not been implemented, such as controlling:

* `lengthAdjust`
* `startOffset`
* `side`
* `textLength`
* `text-anchor`

Note: UprightText is non-functional for now