### PR TITLE
Adding left, centre, right alignment for TextPath, including offset configurations

### DIFF
--- a/pangocairohelpers/__init__.py
+++ b/pangocairohelpers/__init__.py
@@ -1,4 +1,5 @@
-from .glyph_extents import GlyphExtents  # noqa
+from .extent import Extent  # noqa
+from .glyph_extent import GlyphExtent  # noqa
 from . import point_helper  # noqa
 from . import line_helper  # noqa
 from . import line_string_helper  # noqa

--- a/pangocairohelpers/extent.py
+++ b/pangocairohelpers/extent.py
@@ -1,15 +1,13 @@
-class GlyphExtents:
+class Extent:
 
     def __init__(
             self,
             x: float = 0,
             y: float = 0,
             width: float = 0,
-            height: float = 0,
-            baseline: float = 0
+            height: float = 0
     ):
         self.x = x
         self.y = y
         self.width = width
         self.height = height
-        self.baseline = baseline

--- a/pangocairohelpers/glyph_extent.py
+++ b/pangocairohelpers/glyph_extent.py
@@ -1,0 +1,15 @@
+from pangocairohelpers import Extent
+
+
+class GlyphExtent(Extent):
+
+    def __init__(
+            self,
+            x: float = 0,
+            y: float = 0,
+            width: float = 0,
+            height: float = 0,
+            baseline: float = 0
+    ):
+        super().__init__(x, y, width, height)
+        self.baseline = baseline

--- a/pangocairohelpers/layout_clusters.py
+++ b/pangocairohelpers/layout_clusters.py
@@ -1,7 +1,7 @@
 from pangocffi import Layout, GlyphItem, units_to_double
 from typing import List, Optional
 
-from pangocairohelpers import GlyphExtents
+from pangocairohelpers import GlyphExtent
 
 
 class LayoutClusters:
@@ -52,7 +52,7 @@ class LayoutClusters:
                 cluster_extents = layout_cluster_iter.get_cluster_extents()[1]
                 layout_cluster_iter.next_cluster()
                 self.clusters.append(cluster)
-                self.logical_extents.append(GlyphExtents(
+                self.logical_extents.append(GlyphExtent(
                     units_to_double(cluster_extents.x),
                     units_to_double(cluster_extents.y),
                     units_to_double(cluster_extents.width),
@@ -125,9 +125,9 @@ class LayoutClusters:
         """
         return self.clusters
 
-    def get_logical_extents(self) -> List[GlyphExtents]:
+    def get_logical_extents(self) -> List[GlyphExtent]:
         """
         :return:
-            a list of ``GlyphExtents`` for each cluster in the layout
+            a list of ``GlyphExtent`` for each cluster in the layout
         """
         return self.logical_extents

--- a/pangocairohelpers/layout_clusters.py
+++ b/pangocairohelpers/layout_clusters.py
@@ -151,7 +151,7 @@ class LayoutClusters:
         """
         return self.logical_extents
 
-    def get_max_logical_extents(self) -> Optional[Extent]:
+    def get_max_logical_extent(self) -> Optional[Extent]:
         """
         :return:
             the extent of the layout itself

--- a/pangocairohelpers/layout_clusters.py
+++ b/pangocairohelpers/layout_clusters.py
@@ -1,7 +1,7 @@
 from pangocffi import Layout, GlyphItem, units_to_double
 from typing import List, Optional
 
-from pangocairohelpers import GlyphExtent
+from pangocairohelpers import GlyphExtent, Extent
 
 
 class LayoutClusters:
@@ -25,15 +25,20 @@ class LayoutClusters:
         self.text = self.layout.get_text()
         self.clusters = []
         self.logical_extents = []
-        self._extract_properties_from_layout()
+        self.max_logical_extent = None
+        self._extract_logical_extents_from_layout()
+        self._extract_max_logical_extent()
 
-    def _extract_properties_from_layout(self):
+    def _extract_logical_extents_from_layout(self):
         """
-        Iterates over each cluster
+        Iterates over each cluster and extracts the logical extents for each
+        one.
+        """
 
-        Todo: This function uses two different iterators.
-        This probably could do with a bit of refactoring
-        """
+        # Note: two iterators are used, one to iterate over each LayoutRun, and
+        # another to iterate over each GlyphItem cluster.
+        # This probably could do with a bit of refactoring, but this is
+        # currently how Pango works right now.
         layout_run_iter = self.layout.get_iter()
         layout_cluster_iter = self.layout.get_iter()
 
@@ -49,18 +54,32 @@ class LayoutClusters:
 
             clusters = self._get_clusters_from_glyph_item(layout_run)
             for cluster in clusters:
-                cluster_extents = layout_cluster_iter.get_cluster_extents()[1]
+                __, cluster_logical_extent = layout_cluster_iter.\
+                    get_cluster_extents()
                 layout_cluster_iter.next_cluster()
                 self.clusters.append(cluster)
                 self.logical_extents.append(GlyphExtent(
-                    units_to_double(cluster_extents.x),
-                    units_to_double(cluster_extents.y),
-                    units_to_double(cluster_extents.width),
-                    units_to_double(cluster_extents.height),
+                    units_to_double(cluster_logical_extent.x),
+                    units_to_double(cluster_logical_extent.y),
+                    units_to_double(cluster_logical_extent.width),
+                    units_to_double(cluster_logical_extent.height),
                     units_to_double(layout_line_baseline)
                 ))
 
             has_next_run = layout_run_iter.next_run()
+
+    def _extract_max_logical_extent(self):
+        """
+        Extracts the extents of all the clusters (which is essentially the
+        layout extents)
+        """
+        __, layout_logical_extent = self.layout.get_extents()
+        self.max_logical_extent = Extent(
+            units_to_double(layout_logical_extent.x),
+            units_to_double(layout_logical_extent.y),
+            units_to_double(layout_logical_extent.width),
+            units_to_double(layout_logical_extent.height)
+        )
 
     def _split_glyph_item_at_first_cluster(
             self,
@@ -131,3 +150,10 @@ class LayoutClusters:
             a list of ``GlyphExtent`` for each cluster in the layout
         """
         return self.logical_extents
+
+    def get_max_logical_extents(self) -> Optional[Extent]:
+        """
+        :return:
+            the extent of the layout itself
+        """
+        return self.max_logical_extent

--- a/pangocairohelpers/text_path/layout_engines/svg.py
+++ b/pangocairohelpers/text_path/layout_engines/svg.py
@@ -94,11 +94,12 @@ class Svg:
             if line_string_length < offset:
                 break
 
-            center_position = self.line_string.interpolate(offset)
-
-            # Todo: hack
+            # Cut off rendering the beginning of the text if there is no
+            # space to layout the text
             if offset <= 0:
                 continue
+
+            center_position = self.line_string.interpolate(offset)
 
             rotation = line_string_helper.angle_at_offset(
                 angles_at_offsets, offset

--- a/pangocairohelpers/text_path/layout_engines/svg.py
+++ b/pangocairohelpers/text_path/layout_engines/svg.py
@@ -1,10 +1,11 @@
 import math
+from operator import attrgetter
 from typing import List
 
 from pangocffi import Alignment
 from shapely.geometry import LineString
 
-from pangocairohelpers import LayoutClusters, point_helper
+from pangocairohelpers import LayoutClusters, point_helper, GlyphExtents
 from pangocairohelpers import line_string_helper
 from pangocairohelpers.text_path import TextPathGlyphItem
 
@@ -36,6 +37,24 @@ class Svg:
     @start_offset.setter
     def start_offset(self, value: float):
         self._start_offset = float(value)
+
+    def get_max_x_extent_in_layout_cluster(self) -> GlyphExtents:
+        extents = self.layout_clusters.get_logical_extents()
+        return max(extents, key=attrgetter('x'))
+
+    def get_left_aligned_start_offset(self) -> float:
+        return self.start_offset
+
+    def get_center_aligned_start_offset(self) -> float:
+        pass
+
+    def get_right_aligned_start_offset(self) -> float:
+        max_layout_cluster_x_extent = self.get_max_x_extent_in_layout_cluster()
+        max_x = max_layout_cluster_x_extent.x + \
+            max_layout_cluster_x_extent.width
+        if max_x > self.line_string.length:
+            return self.start_offset
+        return self.line_string.length - max_x
 
     def generate_text_path_glyph_items(self) -> List[TextPathGlyphItem]:
         text_path_glyph_items = []

--- a/pangocairohelpers/text_path/layout_engines/svg.py
+++ b/pangocairohelpers/text_path/layout_engines/svg.py
@@ -5,7 +5,7 @@ from typing import List
 from pangocffi import Alignment
 from shapely.geometry import LineString
 
-from pangocairohelpers import LayoutClusters, point_helper, GlyphExtents
+from pangocairohelpers import LayoutClusters, point_helper, GlyphExtent
 from pangocairohelpers import line_string_helper
 from pangocairohelpers.text_path import TextPathGlyphItem
 
@@ -38,7 +38,7 @@ class Svg:
     def start_offset(self, value: float):
         self._start_offset = float(value)
 
-    def get_max_x_extent_in_layout_cluster(self) -> GlyphExtents:
+    def get_max_x_extent_in_layout_cluster(self) -> GlyphExtent:
         extents = self.layout_clusters.get_logical_extents()
         return max(extents, key=attrgetter('x'))
 

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -25,6 +25,7 @@ class TextPath:
             layout: Layout,
             alignment: Alignment = Alignment.LEFT,
             side: Side = Side.LEFT,
+            start_offset: float = 0,
             layout_engine=SvgLayoutEngine
     ):
         """
@@ -54,9 +55,10 @@ class TextPath:
             self.line_string.coords = list(self.line_string.coords)[::-1]
         self.layout_engine = layout_engine(
             self.line_string,
-            self.layout_clusters
+            self.layout_clusters,
         )
         self.layout_engine.alignment = alignment
+        self.layout_engine.start_offset = start_offset
         self.text_path_glyph_items = None
 
     def text_fits(self) -> bool:

--- a/tests/functional/test_layout_clusters.py
+++ b/tests/functional/test_layout_clusters.py
@@ -17,3 +17,30 @@ def test_layout_clusters_properties_have_same_length():
     assert len(layout_clusters.get_logical_extents()) == expected_length
 
     surface.finish()
+
+
+def test_layout_clusters_get_max_logical_extents():
+    surface = SVGSurface(None, 100, 100)
+    cairo_context = Context(surface)
+
+    layout_1 = pangocairocffi.create_layout(cairo_context)
+    layout_1.set_markup('Text with one line')
+    layout_1_clusters = LayoutClusters(layout_1)
+    extent_1 = layout_1_clusters.get_max_logical_extents()
+
+    layout_2 = pangocairocffi.create_layout(cairo_context)
+    layout_2.set_markup('text with\ntwo lines')
+    layout_2_clusters = LayoutClusters(layout_2)
+    extent_2 = layout_2_clusters.get_max_logical_extents()
+
+    assert extent_1.x == 0
+    assert extent_1.y == 0
+    assert extent_1.width > 0
+    assert extent_1.height > 0
+
+    assert extent_2.x == extent_1.x
+    assert extent_2.y == extent_1.y
+    assert extent_1.width != extent_2.width
+    assert extent_1.height * 2 == extent_2.height
+
+    surface.finish()

--- a/tests/functional/test_layout_clusters.py
+++ b/tests/functional/test_layout_clusters.py
@@ -19,19 +19,19 @@ def test_layout_clusters_properties_have_same_length():
     surface.finish()
 
 
-def test_layout_clusters_get_max_logical_extents():
+def test_layout_clusters_get_max_logical_extent():
     surface = SVGSurface(None, 100, 100)
     cairo_context = Context(surface)
 
     layout_1 = pangocairocffi.create_layout(cairo_context)
     layout_1.set_markup('Text with one line')
     layout_1_clusters = LayoutClusters(layout_1)
-    extent_1 = layout_1_clusters.get_max_logical_extents()
+    extent_1 = layout_1_clusters.get_max_logical_extent()
 
     layout_2 = pangocairocffi.create_layout(cairo_context)
     layout_2.set_markup('text with\ntwo lines')
     layout_2_clusters = LayoutClusters(layout_2)
-    extent_2 = layout_2_clusters.get_max_logical_extents()
+    extent_2 = layout_2_clusters.get_max_logical_extent()
 
     assert extent_1.x == 0
     assert extent_1.y == 0

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -2,6 +2,8 @@ from typing import Tuple
 
 from cairocffi import Context, SVGSurface, Surface
 import pangocairocffi
+from pangocffi import Alignment
+from shapely.affinity import translate
 from shapely.geometry import LineString
 import unittest
 
@@ -16,8 +18,17 @@ class TestTextPath(unittest.TestCase):
         cairo_context = Context(surface)
         return surface, cairo_context
 
-    def _create_real_surface(self, filename: str) -> Tuple[Surface, Context]:
-        surface = SVGSurface('tests/output/text_path_%s' % filename, 100, 100)
+    def _create_real_surface(
+            self,
+            filename: str,
+            width: int = 100,
+            height: int = 100
+    ) -> Tuple[Surface, Context]:
+        surface = SVGSurface(
+            'tests/output/text_path_%s' % filename,
+            width,
+            height
+        )
         cairo_context = Context(surface)
         return surface, cairo_context
 
@@ -68,10 +79,97 @@ class TestTextPath(unittest.TestCase):
         cairo_context.stroke()
 
         line_string = LineString([[10, 50], [50, 50], [90, 90]])
+        text_path = TextPath(line_string, layout)
+        text_path.draw(cairo_context)
+
+        debug.draw_line_string(cairo_context, line_string)
+        cairo_context.stroke()
+
+        surface.finish()
+
+    def test_side(self):
+        surface, cairo_context = self._create_real_surface('side.svg')
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語')
+
+        line_string = LineString([[10, 30], [50, 30], [90, 70]])
+        text_path = TextPath(line_string, layout)
+        text_path.draw(cairo_context)
+
+        debug.draw_line_string(cairo_context, line_string)
+        cairo_context.stroke()
+
+        line_string = translate(line_string, 0, 20)
         text_path = TextPath(line_string, layout, side=Side.RIGHT)
         text_path.draw(cairo_context)
 
         debug.draw_line_string(cairo_context, line_string)
         cairo_context.stroke()
+
+        surface.finish()
+
+    def test_alignment_when_no_space(self):
+        surface, cairo_context = self._create_real_surface(
+            'alignment_with_no_space.svg'
+        )
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語')
+
+        line_string = LineString([[10, 30], [90, 30]])
+        text_path = TextPath(line_string, layout, alignment=Alignment.CENTER)
+        text_path.draw(cairo_context)
+        debug.draw_line_string(cairo_context, line_string)
+
+        cairo_context.stroke()
+
+        line_string = translate(line_string, 0, 25)
+        text_path = TextPath(line_string, layout, alignment=Alignment.RIGHT)
+        text_path.draw(cairo_context)
+        debug.draw_line_string(cairo_context, line_string)
+
+        cairo_context.stroke()
+
+        surface.finish()
+
+    def test_alignment(self):
+        surface, cairo_context = self._create_real_surface(
+            'alignment.svg',
+            300,
+            100
+        )
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('<span font="8">Hi from Παν語</span>')
+
+        start_offsets = [-10, 0, 10]
+        alignments = [Alignment.LEFT, Alignment.CENTER, Alignment.RIGHT]
+
+        for start_offset_index, start_offset in enumerate(start_offsets):
+            for alignment_index, alignment in enumerate(alignments):
+                line_string = LineString([
+                    [5, 33 + alignment_index * 20],
+                    [30, 23 + alignment_index * 20],
+                    [50, 20 + alignment_index * 20],
+                    [70, 23 + alignment_index * 20],
+                    [95, 33 + alignment_index * 20]
+                ])
+
+                line_string = translate(
+                    line_string,
+                    start_offset_index * 100,
+                    0
+                )
+
+                text_path = TextPath(
+                    line_string,
+                    layout,
+                    alignment=alignment,
+                    start_offset=start_offset
+                )
+                cairo_context.set_source_rgb(0, 0, 0)
+                text_path.draw(cairo_context)
+
+                cairo_context.set_source_rgba(0, 0, 0, 0.2)
+                debug.draw_line_string(cairo_context, line_string)
+                cairo_context.stroke()
 
         surface.finish()

--- a/tests/unit/test_extent.py
+++ b/tests/unit/test_extent.py
@@ -1,0 +1,13 @@
+import unittest
+
+from pangocairohelpers import Extent
+
+
+class TestExtent(unittest.TestCase):
+
+    def test_constructor(self):
+        extent = Extent(10, 20, 30, 40)
+        assert extent.x == 10
+        assert extent.y == 20
+        assert extent.width == 30
+        assert extent.height == 40

--- a/tests/unit/test_glyph_extent.py
+++ b/tests/unit/test_glyph_extent.py
@@ -1,0 +1,14 @@
+import unittest
+
+from pangocairohelpers import GlyphExtent
+
+
+class TestGlyphExtent(unittest.TestCase):
+
+    def test_constructor(self):
+        glyph_extent = GlyphExtent(10, 20, 30, 40, 50)
+        assert glyph_extent.x == 10
+        assert glyph_extent.y == 20
+        assert glyph_extent.width == 30
+        assert glyph_extent.height == 40
+        assert glyph_extent.baseline == 50


### PR DESCRIPTION
Added the ability to set the `alignment` and `start_offset` for a `TextPath`.

<img width="547" alt="Screenshot 2019-05-18 at 15 28 39" src="https://user-images.githubusercontent.com/3501061/57971151-17971f00-7982-11e9-83a4-6704ca2b1ab5.png">

Also includes:

* Refactoring/Renaming of `GlyphExtents`
* Added `get_max_logical_extent()`