### PR TITLE
Add vertical offset option to TextPath

### DIFF
--- a/pangocairohelpers/line_string_helper.py
+++ b/pangocairohelpers/line_string_helper.py
@@ -262,18 +262,18 @@ def parallel_offset_with_matching_direction(
 
     # Is the start position and angle of the output line similar to the input
     # line?
-    if position_diff_start == distance and \
+    if position_diff_start == abs(distance) and \
        output_angle_start == input_angle_start:
         return result, True
 
     # Is the start position and angle of the reverse output line similar to the
     # input line?
-    if position_diff_end == distance and \
+    if position_diff_end == abs(distance) and \
        output_angle_end == input_angle_start:
         return result_reverse, True
 
     # Is the start position of the output line similar to the input line?
-    if position_diff_start == distance:
+    if position_diff_start == abs(distance):
         return result, True
 
     # Is the start position of the reverse output line similar to the input

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -45,6 +45,7 @@ class TextPath:
 
         self._alignment = Alignment.LEFT
         self._start_offset = 0
+        self._vertical_offset = 0
         self._side = Side.LEFT
 
         self._layout_clusters = LayoutClusters(self._layout)
@@ -97,6 +98,22 @@ class TextPath:
             Defaults to ``0``
         """
         self._start_offset = float(value)
+
+    @property
+    def vertical_offset(self) -> float:
+        return float(self._vertical_offset)
+
+    @vertical_offset.setter
+    def vertical_offset(self, value: float):
+        """
+        :param value:
+            How many units the text should be offset vertically from the
+            ``line_string``. If the line self_intersects, expect for the text
+            path to not render at all.
+
+            Defaults to ``0``
+        """
+        self._vertical_offset = float(value)
 
     @property
     def layout_engine_class(self) -> Type[LayoutEngine]:

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -149,7 +149,8 @@ class TextPath:
             self._modified_line_string, matched_direction = \
                 parallel_offset_with_matching_direction(
                     self._modified_line_string,
-                    self._vertical_offset
+                    self._vertical_offset,
+                    side=Side.LEFT
                 )
 
             if not isinstance(self._modified_line_string, LineString):

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -152,7 +152,7 @@ class TextPath:
                     self._vertical_offset
                 )
 
-            if isinstance(self._modified_line_string, LineString):
+            if not isinstance(self._modified_line_string, LineString):
                 self._modified_line_string = None
                 raise RuntimeError("Failed to offset linestring. "
                                    "Non-linestring object returned.")

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -7,7 +7,7 @@ from pangocairocffi.render_functions import show_glyph_item
 
 from pangocairohelpers import LayoutClusters
 from pangocairohelpers import Side
-from pangocairohelpers.line_string_helper import reverse
+from pangocairohelpers.line_string_helper import reverse, parallel_offset_with_matching_direction
 from pangocairohelpers.text_path.layout_engines import LayoutEngineAbstract
 from pangocairohelpers.text_path.layout_engines import Svg as SvgLayoutEngine
 
@@ -144,6 +144,23 @@ class TextPath:
         self._modified_line_string = self._input_line_string
         if self._side == Side.RIGHT:
             self._modified_line_string = reverse(self._modified_line_string)
+
+        if self._vertical_offset != 0:
+            self._modified_line_string, matched_direction = \
+                parallel_offset_with_matching_direction(
+                    self._modified_line_string,
+                    self._vertical_offset
+                )
+
+            if isinstance(self._modified_line_string, LineString):
+                self._modified_line_string = None
+                raise RuntimeError("Failed to offset linestring. "
+                                   "Non-linestring object returned.")
+
+            if not matched_direction:
+                self._modified_line_string = None
+                raise RuntimeError("Failed to offset linestring. "
+                                   "Direction could not be established.")
 
     def _generate_layout_engine(self):
         self._generate_modified_line_string()

--- a/pangocairohelpers/text_path/text_path.py
+++ b/pangocairohelpers/text_path/text_path.py
@@ -7,7 +7,8 @@ from pangocairocffi.render_functions import show_glyph_item
 
 from pangocairohelpers import LayoutClusters
 from pangocairohelpers import Side
-from pangocairohelpers.line_string_helper import reverse, parallel_offset_with_matching_direction
+from pangocairohelpers.line_string_helper import reverse, \
+    parallel_offset_with_matching_direction
 from pangocairohelpers.text_path.layout_engines import LayoutEngineAbstract
 from pangocairohelpers.text_path.layout_engines import Svg as SvgLayoutEngine
 
@@ -153,7 +154,8 @@ class TextPath:
                     side=Side.LEFT
                 )
 
-            if not isinstance(self._modified_line_string, LineString):
+            if not isinstance(self._modified_line_string, LineString) or \
+                    self._modified_line_string.is_empty:
                 self._modified_line_string = None
                 raise RuntimeError("Failed to offset linestring. "
                                    "Non-linestring object returned.")

--- a/tests/functional/test_line_string_helper.py
+++ b/tests/functional/test_line_string_helper.py
@@ -281,6 +281,17 @@ test_parallel_offset_with_matching_direction_data = [
         LineString([[20, 10], [30, 10], [30, 20], [20, 20], [20, 10]]),
         False
     ),
+    (
+        LineString([[10, 50], [50, 50], [90, 90]]),
+        -10.0,
+        Side.RIGHT,
+        LineString([
+            [10, 40],
+            [54.14213562373096, 40],
+            [97.07106781186548, 82.92893218813452]
+        ]),
+        True
+    )
 ]
 
 

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -45,6 +45,17 @@ class TestTextPath(unittest.TestCase):
         assert isinstance(text_path.side, Side)
         assert isinstance(text_path.alignment, Alignment)
         assert isinstance(text_path.start_offset, float)
+        assert isinstance(text_path.vertical_offset, float)
+
+        text_path.side = Side.RIGHT
+        text_path.alignment = Alignment.RIGHT
+        text_path.start_offset = 12
+        text_path.vertical_offset = 34
+
+        assert isinstance(text_path.side, Side)
+        assert isinstance(text_path.alignment, Alignment)
+        assert isinstance(text_path.start_offset, float)
+        assert isinstance(text_path.vertical_offset, float)
 
         text_path.layout_engine_class = Svg
 

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -8,7 +8,8 @@ from shapely.geometry import LineString
 import unittest
 
 from pangocairohelpers import Side
-from pangocairohelpers.line_string_helper import parallel_offset_with_matching_direction
+from pangocairohelpers.line_string_helper import \
+    parallel_offset_with_matching_direction
 from pangocairohelpers.text_path import TextPath
 from pangocairohelpers.text_path.layout_engines import Svg
 from . import debug

--- a/tests/functional/test_text_path.py
+++ b/tests/functional/test_text_path.py
@@ -8,6 +8,7 @@ from shapely.geometry import LineString
 import unittest
 
 from pangocairohelpers import Side
+from pangocairohelpers.line_string_helper import parallel_offset_with_matching_direction
 from pangocairohelpers.text_path import TextPath
 from pangocairohelpers.text_path.layout_engines import Svg
 from . import debug
@@ -198,5 +199,30 @@ class TestTextPath(unittest.TestCase):
                 cairo_context.set_source_rgba(0, 0, 0, 0.2)
                 debug.draw_line_string(cairo_context, line_string)
                 cairo_context.stroke()
+
+        surface.finish()
+
+    def test_vertical_offset_works(self):
+        surface, cairo_context = self._create_real_surface(
+            'vertical_offset_works.svg'
+        )
+        layout = pangocairocffi.create_layout(cairo_context)
+        layout.set_markup('Hi from Παν語')
+
+        line_string = LineString([[5, 40], [45, 40], [90, 80]])
+
+        for vertical_offset in [-13, 0, 13]:
+            offset_linestring, _ = parallel_offset_with_matching_direction(
+                line_string,
+                vertical_offset
+            )
+            debug.draw_line_string(cairo_context, offset_linestring)
+            cairo_context.set_source_rgba(0, 0, 0, 0.2)
+            cairo_context.stroke()
+
+            text_path = TextPath(line_string, layout)
+            text_path.vertical_offset = vertical_offset
+            cairo_context.set_source_rgb(0, 0, 0)
+            text_path.draw(cairo_context)
 
         surface.finish()


### PR DESCRIPTION
Added additional property to `TextPath` to adjust the vertical offset of the text from the line string.

The vertical offset does have some awkward behaviour because the Shapely library[1] has interesting behaviour when trying to `parallel_offset()` a line string. For example, often it will return an offset line string , but with with the lines revered. But in most cases, it should work "fine".

Below is an example.

* The black text is with 0 units offset
* The red text is with 13 units offset
* The green text is with -13 units offset

<img width="431" alt="Screenshot 2019-05-29 at 22 35 18" src="https://user-images.githubusercontent.com/3501061/58593162-19a28d00-8262-11e9-8af8-60278c384dfc.png">

One might have noticed the flaws with the rotation of the letter "m". This is actually the standard behaviour found in SVG's `<textpath>`. A different `LayoutEngine` would be required to rotate the glyph more reasonably, but that can be easily added later, since the `LayoutEngine` is a class that is configurable for `TexPath`.

* [1] Technically "geos" is the library that does the computation of `parallel_offset`. Shapely is just the name of the python bindings language.